### PR TITLE
Reduce clang warnings

### DIFF
--- a/src/asyncrpcoperation.cpp
+++ b/src/asyncrpcoperation.cpp
@@ -36,10 +36,10 @@ AsyncRPCOperation::AsyncRPCOperation() : error_code_(0), error_message_()
     set_state(OperationStatus::READY);
 }
 
-AsyncRPCOperation::AsyncRPCOperation(const AsyncRPCOperation& o) : id_(o.id_), creation_time_(o.creation_time_), state_(o.state_.load()),
+//AsyncRPCOperation::AsyncRPCOperation(const AsyncRPCOperation& o) : id_(o.id_), creation_time_(o.creation_time_), state_(o.state_.load()),
+AsyncRPCOperation::AsyncRPCOperation(const AsyncRPCOperation& o) : result_(o.result_), error_code_(o.error_code_), error_message_(o.error_message_),
                                                                    start_time_(o.start_time_), end_time_(o.end_time_),
-                                                                   error_code_(o.error_code_), error_message_(o.error_message_),
-                                                                   result_(o.result_)
+                                                                   id_(o.id_)
 {
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -348,44 +348,49 @@ uint32_t CCoinsViewCache::PreloadHistoryTree(uint32_t epochId, bool extra, std::
     uint32_t peak_pos = 0;
     uint32_t total_peaks = 0;
 
-    // Assume the following example peak layout with 14 leaves, and 25 stored nodes in
-    // total (the "tree length"):
-    //
-    //             P
-    //            /\
-    //           /  \
-    //          / \  \
-    //        /    \  \  Altitude
-    //     _A_      \  \    3
-    //   _/   \_     B  \   2
-    //  / \   / \   / \  C  1
-    // /\ /\ /\ /\ /\ /\ /\ 0
-    //
-    // We start by determining the altitude of the highest peak (A).
+    /*
+    Assume the following example peak layout with 14 leaves, and 25 stored nodes in
+    total (the "tree length"):
+    
+                P
+               /\
+              /  \
+             / \  \
+           /    \  \  Altitude
+        _A_      \  \    3
+      _/   \_     B  \   2
+     / \   / \   / \  C  1
+    /\ /\ /\ /\ /\ /\ /\ 0
+    
+    We start by determining the altitude of the highest peak (A).
+    */
     alt = altitude(treeLength);
 
-    // We determine the position of the highest peak (A) by pretending it is the right
-    // sibling in a tree, and its left-most leaf has position 0. Then the left sibling
-    // of (A) has position -1, and so we can "jump" to the peak's position by computing
-    // -1 + 2^(alt + 1) - 1.
+    /*
+    We determine the position of the highest peak (A) by pretending it is the right
+    sibling in a tree, and its left-most leaf has position 0. Then the left sibling
+    of (A) has position -1, and so we can "jump" to the peak's position by computing
+    -1 + 2^(alt + 1) - 1.
+    */
     peak_pos = (1 << (alt + 1)) - 2;
 
-    // Now that we have the position and altitude of the highest peak (A), we collect
-    // the remaining peaks (B, C). We navigate the peaks as if they were nodes in this
-    // Merkle tree (with additional imaginary nodes 1 and 2, that have positions beyond
-    // the MMR's length):
-    //
-    //             / \
-    //            /   \
-    //           /     \
-    //         /         \
-    //       A ==========> 1
-    //      / \          //  \
-    //    _/   \_       B ==> 2
-    //   /\     /\     /\    //
-    //  /  \   /  \   /  \   C
-    // /\  /\ /\  /\ /\  /\ /\
-    //
+    /*
+    Now that we have the position and altitude of the highest peak (A), we collect
+    the remaining peaks (B, C). We navigate the peaks as if they were nodes in this
+    Merkle tree (with additional imaginary nodes 1 and 2, that have positions beyond
+    the MMR's length):
+    
+                / \
+               /   \
+              /     \
+            /         \
+          A ==========> 1
+         / \          //  \
+       _/   \_       B ==> 2
+      /\     /\     /\    //
+     /  \   /  \   /  \   C
+    /\  /\ /\  /\ /\  /\ /\
+    */
     while (alt != 0) {
         // If peak_pos is out of bounds of the tree, we compute the position of its left
         // child, and drop down one level in the tree.
@@ -415,20 +420,21 @@ uint32_t CCoinsViewCache::PreloadHistoryTree(uint32_t epochId, bool extra, std::
     alt = last_peak_alt;
     peak_pos = last_peak_pos;
 
-
-    //             P
-    //            /\
-    //           /  \
-    //          / \  \
-    //        /    \  \
-    //     _A_      \  \
-    //   _/   \_     B  \
-    //  / \   / \   / \  C
-    // /\ /\ /\ /\ /\ /\ /\
-    //                   D E
-    //
-    // For extra peaks needed for deletion, we do extra pass on right slope of the last peak
-    // and add those nodes + their siblings. Extra would be (D, E) for the picture above.
+    /*
+                P
+               /\
+              /  \
+             / \  \
+           /    \  \
+        _A_      \  \
+      _/   \_     B  \
+     / \   / \   / \  C
+    /\ /\ /\ /\ /\ /\ /\
+                      D E
+    
+    For extra peaks needed for deletion, we do extra pass on right slope of the last peak
+    and add those nodes + their siblings. Extra would be (D, E) for the picture above.
+    */
     while (alt > 0) {
         uint32_t left_pos = peak_pos - (1 << alt);
         uint32_t right_pos = peak_pos - 1;

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -562,7 +562,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
                 }
 
                 // 2c) Calculate tuples (X_i ^ X_j, (i, j))
-                bool checking_for_zero = (i == 0 && Xt[0].IsZero(hashLen));
+                //bool checking_for_zero = (i == 0 && Xt[0].IsZero(hashLen));
                 for (int l = 0; l < j - 1; l++) {
                     for (int m = l + 1; m < j; m++) {
                         // We truncated, so don't check for distinct indices here

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -644,9 +644,7 @@ void CleanupBlockRevFiles()
     // keeping a separate counter.  Once we hit a gap (or if 0 doesn't exist)
     // start removing block files.
     int nContigCounter = 0;
-    for (const PAIRTYPE(string, path) &
-             item :
-         mapBlockFiles) {
+    for (const std::pair<const string, path> & item : mapBlockFiles) {
         if (atoi(item.first) == nContigCounter) {
             nContigCounter++;
             continue;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -50,21 +50,27 @@ std::atomic<bool> fReopenDebugLog(false);
  * the OS/libc. When the shutdown sequence is fully audited and
  * tested, explicit destruction of these objects can be implemented.
  */
-//static FILE* fileout = NULL;
-static boost::mutex* mutexDebugLog = NULL;
-static list<string> *vMsgsBeforeOpenLog;
+//static FILE* fileout = NULL;				// -Wunused-variable	// Ky
+//static boost::mutex* mutexDebugLog = NULL;		// -Wunused-variable	// Ky
+//static list<string> *vMsgsBeforeOpenLog;		// -Wunused-variable	// Ky
 
+// -Wunused-function	// Ky
+/*
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
 }
+*/
 
+// -Wunused-function	// Ky
+/*
 static void DebugPrintInit()
 {
     assert(mutexDebugLog == NULL);
     mutexDebugLog = new boost::mutex();
     vMsgsBeforeOpenLog = new list<string>;
 }
+*/
 
 fs::path GetDebugLogPath()
 {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -39,7 +39,7 @@ std::atomic<bool> fReopenDebugLog(false);
  * the mutex).
  */
 
-static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
+//static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
 
 /**
  * We use boost::call_once() to make sure mutexDebugLog and
@@ -50,7 +50,7 @@ static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
  * the OS/libc. When the shutdown sequence is fully audited and
  * tested, explicit destruction of these objects can be implemented.
  */
-static FILE* fileout = NULL;
+//static FILE* fileout = NULL;
 static boost::mutex* mutexDebugLog = NULL;
 static list<string> *vMsgsBeforeOpenLog;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3776,6 +3776,7 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
     return true;
 }
 
+/*
 static void NotifyHeaderTip(const Consensus::Params& params)
 {
     bool fNotify = false;
@@ -3798,6 +3799,7 @@ static void NotifyHeaderTip(const Consensus::Params& params)
         uiInterface.NotifyHeaderTip(fInitialBlockDownload, pindexHeader);
     }
 }
+*/
 
 
 /**
@@ -4573,6 +4575,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, const CChainParams& cha
     return true;
 }
 
+/*
 static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams)
 {
     unsigned int nFound = 0;
@@ -4583,6 +4586,7 @@ static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned 
     }
     return (nFound >= nRequired);
 }
+*/
 
 
 bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, CNode* pfrom, CBlock* pblock, bool fForceProcessing, CDiskBlockPos* dbp)
@@ -6357,7 +6361,7 @@ bool static ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         bool ignoreFees = false;
         CTxIn vin;
         vector<unsigned char> vchSig;
-        int64_t sigTime;
+        //int64_t sigTime;
 
         vRecv >> tx;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ void EraseOrphansFor(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
  * Returns true if there are nRequired or more blocks of minVersion or above
  * in the last Consensus::Params::nMajorityWindow blocks, starting at pstart and going backwards.
  */
-static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
+//static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
 static void CheckBlockIndex();
 
 /** Constant stuff for coinbase transactions we create: */
@@ -1731,7 +1731,7 @@ bool AcceptToMemoryPool(const CChainParams& chainparams, CTxMemPool& pool, CVali
         }
     }
 
-    int nHeight = chainActive.Tip() ? chainActive.Tip()->nHeight : 0;
+    //int nHeight = chainActive.Tip() ? chainActive.Tip()->nHeight : 0		// -Wunused-variable, 	// Ky
     // SyncWithWallets(tx, NULL, nHeight);
 
     return true;
@@ -3816,7 +3816,7 @@ bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams,
         boost::this_thread::interruption_point();
 
         bool fInitialDownload;
-        int nNewHeight;
+        int nNewHeight;		// ** NOTE: clang compiler will falsly warn about -Wunused-but-set-variable here; this is required // Ky
         {
             LOCK(cs_main);
             pindexMostWork = FindMostWorkChain();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1574,7 +1574,7 @@ bool AcceptToMemoryPool(const CChainParams& chainparams, CTxMemPool& pool, CVali
             // do all inputs exist?
             // Note that this does not check for the presence of actual outputs (see the next check for that),
             // and only helps with filling in pfMissingInputs (to determine missing vs spent).
-            for (const CTxIn txin : tx.vin) {
+            for (const CTxIn & txin : tx.vin) {
                 if (!view.HaveCoins(txin.prevout.hash)) {
                     if (pfMissingInputs)
                         *pfMissingInputs = true;
@@ -1855,7 +1855,7 @@ bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransact
             // do all inputs exist?
             // Note that this does not check for the presence of actual outputs (see the next check for that),
             // only helps filling in pfMissingInputs (to determine missing vs spent).
-            for (const CTxIn txin : tx.vin) {
+            for (const CTxIn & txin : tx.vin) {
                 if (!view.HaveCoins(txin.prevout.hash)) {
                     if (pfMissingInputs)
                         *pfMissingInputs = true;
@@ -4839,7 +4839,7 @@ bool static LoadBlockIndexDB()
     // Calculate nChainWork
     vector<pair<int, CBlockIndex*>> vSortedByHeight;
     vSortedByHeight.reserve(mapBlockIndex.size());
-    for (const std::pair<uint256, CBlockIndex*>& item : mapBlockIndex) {
+    for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
         CBlockIndex* pindex = item.second;
         vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
     }
@@ -4926,7 +4926,7 @@ bool static LoadBlockIndexDB()
     // Check presence of blk files
     LogPrintf("Checking all blk files are present...\n");
     set<int> setBlkDataFiles;
-    for (const std::pair<uint256, CBlockIndex*>& item : mapBlockIndex) {
+    for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
         CBlockIndex* pindex = item.second;
         if (pindex->nStatus & BLOCK_HAVE_DATA) {
             setBlkDataFiles.insert(pindex->nFile);
@@ -4971,7 +4971,7 @@ bool static LoadBlockIndexDB()
     }
 
     // Fill in-memory data
-    for (const std::pair<uint256, CBlockIndex*>& item : mapBlockIndex) {
+    for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
         CBlockIndex* pindex = item.second;
         // - This relationship will always be true even if pprev has multiple
         //   children, because hashSproutAnchor is technically a property of pprev,

--- a/src/main.h
+++ b/src/main.h
@@ -48,8 +48,8 @@ class CInv;
 class CScriptCheck;
 class CValidationInterface;
 class CValidationState;
-class PrecomputedTransactionData;
 
+struct PrecomputedTransactionData;
 struct CNodeStateStats;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1268,7 +1268,7 @@ void CBudgetManager::Sync(CNode* pfrom, const uint256& nProp, bool fPartial)
     */
     int nInvCount = 0;
 
-    std::map<uint256, CBudgetProposalBroadcast>::iterator it1 = mapSeenMasternodeBudgetProposals.begin();
+    //std::map<uint256, CBudgetProposalBroadcast>::iterator it1 = mapSeenMasternodeBudgetProposals.begin();	// -Wunused-variable
     for (auto& it : mapSeenMasternodeBudgetProposals) {
         CBudgetProposal* pbudgetProposal = FindProposal(it.first);
         if (pbudgetProposal && pbudgetProposal->IsValid() && (nProp.IsNull() || it.first == nProp)) {
@@ -1670,10 +1670,10 @@ void CBudgetProposalBroadcast::Relay()
 CBudgetVote::CBudgetVote() : CSignedMessage(),
                              fValid(true),
                              fSynced(false),
-                             vin(),
                              nProposalHash(uint256()),
                              nVote(VOTE_ABSTAIN),
-                             nTime(0)
+                             nTime(0),
+                             vin()
 {
     const bool fNewSigs = NetworkUpgradeActive(chainActive.Height() + 1, Params().GetConsensus(), Consensus::UPGRADE_MORAG);
     if (fNewSigs) {
@@ -1684,10 +1684,10 @@ CBudgetVote::CBudgetVote() : CSignedMessage(),
 CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, VoteDirection nVoteIn) : CSignedMessage(),
                                                                                         fValid(true),
                                                                                         fSynced(false),
-                                                                                        vin(vinIn),
                                                                                         nProposalHash(nProposalHashIn),
                                                                                         nVote(nVoteIn),
-                                                                                        nTime(GetAdjustedTime())
+                                                                                        nTime(GetAdjustedTime()),
+                                                                                        vin(vinIn)
 {
     const bool fNewSigs = NetworkUpgradeActive(chainActive.Height() + 1, Params().GetConsensus(), Consensus::UPGRADE_MORAG);
     if (fNewSigs) {
@@ -1730,21 +1730,22 @@ UniValue CBudgetVote::ToJSON() const
 
 CFinalizedBudget::CFinalizedBudget() : fAutoChecked(false),
                                        fValid(true),
-                                       strBudgetName(""),
                                        strInvalid(),
+                                       strBudgetName(""),
                                        nBlockStart(0),
                                        vecBudgetPayments(),
                                        mapVotes(),
-                                       nTime(0),
-                                       nFeeTXHash(uint256())
+                                       nFeeTXHash(uint256()),
+                                       nTime(0)
+
 {
 }
 CFinalizedBudget::CFinalizedBudget(const CFinalizedBudget& other) : fAutoChecked(false),
                                                                     fValid(true),
+                                                                    strInvalid(),
                                                                     strBudgetName(other.strBudgetName),
                                                                     nBlockStart(other.nBlockStart),
                                                                     vecBudgetPayments(other.vecBudgetPayments),
-                                                                    strInvalid(),
                                                                     mapVotes(other.mapVotes),
                                                                     nFeeTXHash(other.nFeeTXHash),
                                                                     nTime(other.nTime)

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -56,7 +56,7 @@ bool IsBudgetCollateralValid(const uint256& nTxCollateralHash, const uint256& nE
     findScript << OP_RETURN << ToByteVector(nExpectedHash);
 
     bool foundOpReturn = false;
-    for (const CTxOut o : txCollateral.vout) {
+    for (const CTxOut & o : txCollateral.vout) {
         if (!o.scriptPubKey.IsNormalPaymentScript() && !o.scriptPubKey.IsUnspendable()) {
             strError = strprintf("Invalid Script %s", txCollateral.ToString());
             LogPrint("masternode", "CBudgetProposalBroadcast::IsBudgetCollateralValid - %s\n", strError);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -605,7 +605,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     tx.vin.push_back(vin);
     tx.vout.push_back(vout);
 
-    int nChainHeight = 0;
+    int nChainHeight = 0;	// ** NOTE: clang compiler will falsly warn about -Wunused-but-set-variable here; this is required // Ky
     {
         TRY_LOCK(cs_main, lockMain);
         if (!lockMain) {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -35,7 +35,7 @@ bool CheckBlockTimestamp(const CBlockIndex* pindexLast, const CBlockHeader* pblo
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader* pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
-    unsigned int nProofOfWorkLimitTop = UintToArith256(params.powLimitTop).GetCompact();
+    //unsigned int nProofOfWorkLimitTop = UintToArith256(params.powLimitTop).GetCompact();
 
     // Genesis block
     if (pindexLast == NULL)
@@ -142,7 +142,8 @@ unsigned int Lwma3CalculateNextWorkRequired(const CBlockIndex* pindexLast, const
 
     arith_uint256 sumTarget, previousDiff, nextTarget;
     int64_t thisTimestamp, previousTimestamp;
-    int64_t t = 0, j = 0, solvetimeSum = 0;
+    //int64_t t = 0, j = 0, solvetimeSum = 0;
+    int64_t t = 0, j = 0;
 
     const CBlockIndex* blockPreviousTimestamp = pindexLast->GetAncestor(height - N);
     previousTimestamp = blockPreviousTimestamp->GetBlockTime();

--- a/src/pow/tromp/equi_miner.h
+++ b/src/pow/tromp/equi_miner.h
@@ -374,7 +374,7 @@ struct equi {
   struct collisiondata {
 #ifdef XBITMAP
 #if NSLOTS > 64
-#error can't use XBITMAP with more than 64 slots
+#error cannot use XBITMAP with more than 64 slots
 #endif
     u64 xhashmap[NRESTS];
     u64 xmap;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -116,7 +116,8 @@ CTransaction::CTransaction(const CMutableTransaction& tx) : nVersion(tx.nVersion
 // For developer testing only.
 CTransaction::CTransaction(
     const CMutableTransaction& tx,
-    bool evilDeveloperFlag) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
+    //bool evilDeveloperFlag) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
+    bool evilDeveloperFlag) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
                               vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
                               valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                               vjoinsplit(tx.vjoinsplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
@@ -125,7 +126,8 @@ CTransaction::CTransaction(
     assert(evilDeveloperFlag);
 }
 
-CTransaction::CTransaction(CMutableTransaction&& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId),
+//CTransaction::CTransaction(CMutableTransaction&& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId),
+CTransaction::CTransaction(CMutableTransaction&& tx) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId),
                                                        vin(std::move(tx.vin)), vout(std::move(tx.vout)), nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
                                                        valueBalance(tx.valueBalance),
                                                        vShieldedSpend(std::move(tx.vShieldedSpend)), vShieldedOutput(std::move(tx.vShieldedOutput)),

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -82,9 +82,10 @@ std::string CTxOut::ToString() const
     return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s, address=%s)", nValue / COIN, nValue % COIN, HexStr(scriptPubKey).substr(0, 30), keyIO.EncodeDestination(address1));
 }
 
-CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), nLockTime(0), valueBalance(0) {}
-CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
-                                                                   vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
+CMutableTransaction::CMutableTransaction() : fOverwintered(false), nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), nVersionGroupId(0), nLockTime(0), nExpiryHeight(0), valueBalance(0) {}
+CMutableTransaction::CMutableTransaction(const CTransaction& tx) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId),
+                                                                   vin(tx.vin), vout(tx.vout),
+                                                                   nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
                                                                    valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                                                                    vjoinsplit(tx.vjoinsplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                                    bindingSig(tx.bindingSig)
@@ -101,10 +102,10 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
-CTransaction::CTransaction() : nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), fOverwintered(false), nVersionGroupId(0), nExpiryHeight(0), vin(), vout(), nLockTime(0), valueBalance(0), vShieldedSpend(), vShieldedOutput(), vjoinsplit(), joinSplitPubKey(), joinSplitSig(), bindingSig() {}
+CTransaction::CTransaction() : fOverwintered(false), nVersion(CTransaction::SPROUT_MIN_CURRENT_VERSION), nVersionGroupId(0), vin(), vout(), nLockTime(0), nExpiryHeight(0), valueBalance(0), vShieldedSpend(), vShieldedOutput(), vjoinsplit(), joinSplitPubKey(), joinSplitSig(), bindingSig() {}
 
-CTransaction::CTransaction(const CMutableTransaction& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
-                                                            vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
+CTransaction::CTransaction(const CMutableTransaction& tx) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId),
+                                                            vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
                                                             valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                                                             vjoinsplit(tx.vjoinsplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                                                             bindingSig(tx.bindingSig)
@@ -116,9 +117,8 @@ CTransaction::CTransaction(const CMutableTransaction& tx) : nVersion(tx.nVersion
 // For developer testing only.
 CTransaction::CTransaction(
     const CMutableTransaction& tx,
-    //bool evilDeveloperFlag) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
-    bool evilDeveloperFlag) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId), nExpiryHeight(tx.nExpiryHeight),
-                              vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime),
+    bool evilDeveloperFlag) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId),
+                              vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
                               valueBalance(tx.valueBalance), vShieldedSpend(tx.vShieldedSpend), vShieldedOutput(tx.vShieldedOutput),
                               vjoinsplit(tx.vjoinsplit), joinSplitPubKey(tx.joinSplitPubKey), joinSplitSig(tx.joinSplitSig),
                               bindingSig(tx.bindingSig)
@@ -126,7 +126,6 @@ CTransaction::CTransaction(
     assert(evilDeveloperFlag);
 }
 
-//CTransaction::CTransaction(CMutableTransaction&& tx) : nVersion(tx.nVersion), fOverwintered(tx.fOverwintered), nVersionGroupId(tx.nVersionGroupId),
 CTransaction::CTransaction(CMutableTransaction&& tx) : fOverwintered(tx.fOverwintered), nVersion(tx.nVersion), nVersionGroupId(tx.nVersionGroupId),
                                                        vin(std::move(tx.vin)), vout(std::move(tx.vout)), nLockTime(tx.nLockTime), nExpiryHeight(tx.nExpiryHeight),
                                                        valueBalance(tx.valueBalance),

--- a/src/proof_verifier.cpp
+++ b/src/proof_verifier.cpp
@@ -21,7 +21,8 @@ public:
         ProofVerifier& verifier,
         const Ed25519VerificationKey& joinSplitPubKey,
         const JSDescription& jsdesc
-        ) : jsdesc(jsdesc), verifier(verifier), joinSplitPubKey(joinSplitPubKey) {}
+        //) : jsdesc(jsdesc), verifier(verifier), joinSplitPubKey(joinSplitPubKey) {}
+        ) : verifier(verifier), joinSplitPubKey(joinSplitPubKey), jsdesc(jsdesc) {}
 
     bool operator()(const libzcash::PHGRProof& proof) const
     {

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -21,6 +21,8 @@
 
 #include <librustzcash.h>
 
+// -Wunused-function	// Ky
+/*
 static inline int64_t GetPerformanceCounter()
 {
     int64_t nCounter = 0;
@@ -33,6 +35,7 @@ static inline int64_t GetPerformanceCounter()
 #endif
     return nCounter;
 }
+*/
 
 void GetRandBytes(unsigned char* buf, size_t num)
 {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -478,8 +478,8 @@ UniValue startmasternode(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
         bool found = false;
-        int successful = 0;
-        int failed = 0;
+        //int successful = 0;
+        //int failed = 0;
 
         UniValue resultsObj(UniValue::VARR);
         UniValue statusObj(UniValue::VOBJ);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -128,7 +128,7 @@ UniValue getalldata(const UniValue& params, bool fHelp)
 
             isminetype mine = pwalletMain ? IsMine(*pwalletMain, dest) : ISMINE_NO;
 
-            const string& strName = item.second.name;
+            //const string& strName = item.second.name;
             nBalance = getBalanceTaddr(keyIO.EncodeDestination(dest), nMinDepth, false);
 
             addr.push_back(Pair("amount", ValueFromAmount(nBalance)));
@@ -208,7 +208,7 @@ UniValue getalldata(const UniValue& params, bool fHelp)
     // get transactions
     string strAccount = "";
     int nCount = 200;
-    int nFrom = 0;
+    //int nFrom = 0;
     isminefilter filter = ISMINE_SPENDABLE;
 
     UniValue trans(UniValue::VARR);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -448,7 +448,7 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);
-        for (const PAIRTYPE(CNetAddr, LocalServiceInfo) & item : mapLocalHost) {
+	for (const std::pair<const CNetAddr, LocalServiceInfo> & item : mapLocalHost) {
             UniValue rec(UniValue::VOBJ);
             rec.push_back(Pair("address", item.first.ToString()));
             rec.push_back(Pair("port", item.second.nPort));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -109,7 +109,7 @@ UniValue TxJoinSplitToJSON(const CTransaction& tx)
 
         {
             UniValue ciphertexts(UniValue::VARR);
-            for (const ZCNoteEncryption::Ciphertext ct : jsdescription.ciphertexts) {
+            for (const ZCNoteEncryption::Ciphertext & ct : jsdescription.ciphertexts) {
                 ciphertexts.push_back(HexStr(ct.begin(), ct.end()));
             }
             joinsplit.push_back(Pair("ciphertexts", ciphertexts));

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -53,7 +53,7 @@ the bad alert.
 #include "alertkeys.h"
 
 
-static const int64_t DAYS = 24 * 60 * 60;
+//static const int64_t DAYS = 24 * 60 * 60;
 
 void ThreadSendAlert()
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1059,7 +1059,7 @@ void Unserialize(Stream& is, std::list<T, A>& l)
 {
     l.clear();
     unsigned int nSize = ReadCompactSize(is);
-    typename std::list<T, A>::iterator it = l.begin();
+    //typename std::list<T, A>::iterator it = l.begin();	// -Wunused-variable
     for (unsigned int i = 0; i < nSize; i++) {
         T item;
         Unserialize(is, item);

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -62,7 +62,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
             return;
         }
 
-        for (const CTxOut o : tx.vout) {
+        for (const CTxOut & o : tx.vout) {
             // IX supports normal scripts and unspendable scripts (used in DS collateral and Budget collateral).
             // TODO: Look into other script types that are normal and can be included
             if (!o.scriptPubKey.IsNormalPaymentScript() && !o.scriptPubKey.IsUnspendable()) {
@@ -180,10 +180,10 @@ bool IsIXTXValid(const CTransaction& txCollateral)
     CAmount nValueOut = 0;
     bool missingTx = false;
 
-    for (const CTxOut o : txCollateral.vout)
+    for (const CTxOut & o : txCollateral.vout)
         nValueOut += o.nValue;
 
-    for (const CTxIn i : txCollateral.vin) {
+    for (const CTxIn & i : txCollateral.vin) {
         CTransaction tx2;
         uint256 hash;
         if (GetTransaction(i.prevout.hash, tx2, Params().GetConsensus(), hash, true)) {

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -220,7 +220,7 @@ bool IsIXTXValid(const CTransaction& txCollateral)
 
 int64_t CreateNewLock(CTransaction tx)
 {
-    int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(););
+    //int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(););	// -Wunused-variable
     int64_t nTxAge = 0;
     BOOST_REVERSE_FOREACH (CTxIn i, tx.vin) {
         nTxAge = GetInputAge(i);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -503,7 +503,7 @@ bool CBlockTreeDB::WriteTimestampBlockIndex(const CTimestampBlockIndexKey &block
 
 bool CBlockTreeDB::ReadTimestampBlockIndex(const uint256 &hash, unsigned int &ltimestamp)
 {
-    CTimestampBlockIndexValue(lts);
+    CTimestampBlockIndexValue lts;
     if (!Read(std::make_pair(DB_BLOCKHASHINDEX, hash), lts))
         return false;
 

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -224,7 +224,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
     bool isPureTaddrOnlyTx = (sproutNoteInputs_.empty() && saplingNoteInputs_.empty() && isToTaddr_);
     CAmount minersFee = fee_;
 
-    size_t numInputs = utxoInputs_.size();
+    //size_t numInputs = utxoInputs_.size();
 
     CAmount t_inputs_total = 0;
     for (MergeToAddressInputUTXO& t : utxoInputs_) {

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -66,8 +66,9 @@ AsyncRPCOperation_mergetoaddress::AsyncRPCOperation_mergetoaddress(
     MergeToAddressRecipient recipient,
     CAmount fee,
     UniValue contextInfo) :
-    tx_(contextualTx), utxoInputs_(utxoInputs), sproutNoteInputs_(sproutNoteInputs),
-    saplingNoteInputs_(saplingNoteInputs), recipient_(recipient), fee_(fee), contextinfo_(contextInfo)
+    contextinfo_(contextInfo), fee_(fee), recipient_(recipient),
+    utxoInputs_(utxoInputs), sproutNoteInputs_(sproutNoteInputs), saplingNoteInputs_(saplingNoteInputs),
+    tx_(contextualTx)
 {
     if (fee < 0 || fee > MAX_MONEY) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Fee is out of range");

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -67,7 +67,8 @@ AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
     std::vector<SendManyRecipient> zOutputs,
     int minDepth,
     CAmount fee,
-    UniValue contextInfo) : tx_(contextualTx), fromaddress_(fromAddress), t_outputs_(tOutputs), z_outputs_(zOutputs), mindepth_(minDepth), fee_(fee), contextinfo_(contextInfo)
+    //UniValue contextInfo) : tx_(contextualTx), fromaddress_(fromAddress), t_outputs_(tOutputs), z_outputs_(zOutputs), mindepth_(minDepth), fee_(fee), contextinfo_(contextInfo)
+    UniValue contextInfo) : contextinfo_(contextInfo), fee_(fee), mindepth_(minDepth), fromaddress_(fromAddress), t_outputs_(tOutputs), z_outputs_(zOutputs), tx_(contextualTx)
 {
     assert(fee_ >= 0);
 

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -25,7 +25,7 @@
 #include <rust/ed25519/types.h>
 
 using namespace libzcash;
-class TxValues;
+struct TxValues;
 
 class SendManyRecipient {
 public:

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -42,6 +42,8 @@
 
 using namespace libzcash;
 
+// -Wunused-function	// Ky
+/*
 static int find_output(UniValue obj, int n) {
     UniValue outputMapValue = find_value(obj, "outputmap");
     if (!outputMapValue.isArray()) {
@@ -58,6 +60,7 @@ static int find_output(UniValue obj, int n) {
 
     throw std::logic_error("n is not present in outputmap");
 }
+*/
 
 AsyncRPCOperation_shieldcoinbase::AsyncRPCOperation_shieldcoinbase(
         TransactionBuilder builder,
@@ -66,7 +69,7 @@ AsyncRPCOperation_shieldcoinbase::AsyncRPCOperation_shieldcoinbase(
         std::string toAddress,
         CAmount fee,
         UniValue contextInfo) :
-        builder_(builder), tx_(contextualTx), inputs_(inputs), fee_(fee), contextinfo_(contextInfo)
+        contextinfo_(contextInfo), fee_(fee), inputs_(inputs), builder_(builder), tx_(contextualTx)
 {
     assert(contextualTx.nVersion >= 2);  // transaction format version must support vjoinsplit
 
@@ -190,7 +193,7 @@ bool AsyncRPCOperation_shieldcoinbase::main_impl() {
 
     CAmount minersFee = fee_;
 
-    size_t numInputs = inputs_.size();
+    //size_t numInputs = inputs_.size();	// -Wunused-variable	// Ky
 
     CAmount targetAmount = 0;
     for (ShieldCoinbaseUTXO & utxo : inputs_) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -365,7 +365,7 @@ UniValue getaddressesbyaccount(const UniValue& params, bool fHelp)
     KeyIO keyIO(Params());
     // Find all addresses that have the given account
     UniValue ret(UniValue::VARR);
-    for (const std::pair<CTxDestination, CAddressBookData>& item : pwalletMain->mapAddressBook) {
+    for (const std::pair<const CTxDestination, CAddressBookData>& item : pwalletMain->mapAddressBook) {
         const CTxDestination& dest = item.first;
         const std::string& strName = item.second.name;
         if (strName == strAccount) {
@@ -1363,7 +1363,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
 
     // Tally
     std::map<CTxDestination, tallyitem> mapTally;
-    for (const std::pair<uint256, CWalletTx>& pairWtx : pwalletMain->mapWallet) {
+    for (const std::pair<const uint256, CWalletTx>& pairWtx : pwalletMain->mapWallet) {
         const CWalletTx& wtx = pairWtx.second;
 
         if (wtx.IsCoinBase() || !CheckFinalTx(wtx))
@@ -1395,7 +1395,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
     UniValue ret(UniValue::VARR);
     std::map<std::string, tallyitem> mapAccountTally;
     KeyIO keyIO(Params());
-    for (const std::pair<CTxDestination, CAddressBookData>& item : pwalletMain->mapAddressBook) {
+    for (const std::pair<const CTxDestination, CAddressBookData>& item : pwalletMain->mapAddressBook) {
         const CTxDestination& dest = item.first;
         const std::string& strAccount = item.second.name;
         std::map<CTxDestination, tallyitem>::iterator it = mapTally.find(dest);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3110,7 +3110,7 @@ UniValue zc_raw_joinsplit(const UniValue& params, bool fHelp)
     CAmount vpub_old(0);
     CAmount vpub_new(0);
 
-    int nextBlockHeight = chainActive.Height() + 1;
+    //int nextBlockHeight = chainActive.Height() + 1;	// -Wunused-variable
 
     if (params[3].get_real() != 0.0) {
         vpub_old = AmountFromValue(params[3]);
@@ -4817,7 +4817,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     // Keep track of addresses to spot duplicates
     std::set<std::string> setAddress;
 
-    bool isFromNonSprout = false;
+    bool isFromNonSprout = false;	// ** NOTE: clang compiler will falsly warn about -Wunused-but-set-variable here; this is required // Ky
 
     KeyIO keyIO(Params());
     // Sources
@@ -4866,7 +4866,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     }
 
     const int nextBlockHeight = chainActive.Height() + 1;
-    const bool overwinterActive = Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_OVERWINTER);
+    //const bool overwinterActive = Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_OVERWINTER);	// -Wunused-variable
     const bool saplingActive =  Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_SAPLING);
 
     // Validate the destination address

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1401,7 +1401,7 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
         pcoinsTip->GetSproutAnchorAt(blockRoot, sproutTree);
 
         //Cycle through blocks and transactions building sprout tree until the commitment needed is reached
-        const CBlock* pblock;
+        const CBlock* pblock;	// ** NOTE: clang compiler will falsly warn about -Wunused-but-set-variable here; this is required // Ky
         CBlock block;
         ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
         pblock = &block;
@@ -1491,7 +1491,7 @@ int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex, bool witnessO
         pcoinsTip->GetSaplingAnchorAt(blockRoot, saplingTree);
 
         //Cycle through blocks and transactions building sapling tree until the commitment needed is reached
-        const CBlock* pblock;
+        const CBlock* pblock;	// ** NOTE: clang compiler will falsly warn about -Wunused-but-set-variable here; this is required // Ky
         CBlock block;
         ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
         pblock = &block;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4888,7 +4888,7 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
         if (fFileBacked) {
             // Delete destdata tuples associated with address
             std::string strAddress = keyIO.EncodeDestination(address);
-            for (const PAIRTYPE(string, string) & item : mapAddressBook[address].destdata) {
+            for (const std::pair<const string, string> & item : mapAddressBook[address].destdata) {
                 CWalletDB(strWalletFile).EraseDestData(strAddress, item.first);
             }
         }
@@ -5172,7 +5172,7 @@ std::set<CTxDestination> CWallet::GetAccountAddresses(const std::string& strAcco
 {
     LOCK(cs_wallet);
     set<CTxDestination> result;
-    for (const PAIRTYPE(CTxDestination, CAddressBookData) & item : mapAddressBook) {
+    for (const std::pair<const CTxDestination, CAddressBookData> & item : mapAddressBook) {
         const CTxDestination& address = item.first;
         const string& strName = item.second.name;
         if (strName == strAccount)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -315,8 +315,10 @@ public:
      * See the comment in that class for a full description.
      */
     SaplingNoteData() : witnessHeight {-1}, nullifier(), witnessRootValidated {false} { }
-    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk) : ivk {ivk}, witnessHeight {-1}, nullifier(), witnessRootValidated {false} { }
-    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk, uint256 n) : ivk {ivk}, witnessHeight {-1}, nullifier(n), witnessRootValidated {false} { }
+    //SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk) : ivk {ivk}, witnessHeight {-1}, nullifier(), witnessRootValidated {false} { }
+    //SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk, uint256 n) : ivk {ivk}, witnessHeight {-1}, nullifier(n), witnessRootValidated {false} { }
+    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk) : witnessHeight {-1}, ivk {ivk}, nullifier(), witnessRootValidated {false} { }
+    SaplingNoteData(libzcash::SaplingIncomingViewingKey ivk, uint256 n) : witnessHeight {-1}, ivk {ivk}, nullifier(n), witnessRootValidated {false} { }
 
     std::list<SaplingWitness> witnesses;
     int witnessHeight;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -159,7 +159,7 @@ struct CRecipient {
 typedef std::map<std::string, std::string> mapValue_t;
 
 
-static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
+static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (!mapValue.count("n")) {
         nOrderPos = -1; // TODO: calculate elsewhere
@@ -169,7 +169,7 @@ static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 }
 
 
-static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
+static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (nOrderPos == -1)
         return;

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -92,7 +92,7 @@ std::pair<std::string, int64_t> GetWarnings(const std::string& strFor)
     // Alerts
     {
         LOCK(cs_mapAlerts);
-        for (const std::pair<uint256, CAlert>& item : mapAlerts)
+        for (const std::pair<const uint256, CAlert>& item : mapAlerts)
         {
             const CAlert& alert = item.second;
             if (alert.AppliesToMe() && alert.nPriority > nPriority)

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -62,7 +62,8 @@ public:
     uint256 pk_d;
 
     SaplingNote(diversifier_t d, uint256 pk_d, uint64_t value, uint256 rseed, Zip212Enabled zip_212_enabled)
-            : BaseNote(value), d(d), pk_d(pk_d), rseed(rseed), zip_212_enabled(zip_212_enabled) {}
+//            : BaseNote(value), d(d), pk_d(pk_d), rseed(rseed), zip_212_enabled(zip_212_enabled) {}
+            : BaseNote(value), rseed(rseed), zip_212_enabled(zip_212_enabled), d(d), pk_d(pk_d) {}
 
     SaplingNote(const SaplingPaymentAddress &address, uint64_t value, Zip212Enabled zip_212_enabled);
 

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -128,7 +128,7 @@ std::vector<double> benchmark_create_joinsplit_threaded(int nThreads)
         tasks.emplace_back(task.get_future());
         threads.emplace_back(std::move(task));
     }
-    std::future_status status;
+    //std::future_status status;	// -Wunused-variable
     for (auto it = tasks.begin(); it != tasks.end(); it++) {
         it->wait();
         ret.push_back(it->get());
@@ -157,7 +157,7 @@ double benchmark_solve_equihash()
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << I;
 
-    const Consensus::Params& params = Params(CBaseChainParams::MAIN).GetConsensus();
+    //const Consensus::Params& params = Params(CBaseChainParams::MAIN).GetConsensus();	// -Wunused-variable
     unsigned int n = 200;
     unsigned int k = 9;
     eh_HashState eh_state;
@@ -185,7 +185,7 @@ std::vector<double> benchmark_solve_equihash_threaded(int nThreads)
         tasks.emplace_back(task.get_future());
         threads.emplace_back(std::move(task));
     }
-    std::future_status status;
+    //std::future_status status;	// -Wunused-variable
     for (auto it = tasks.begin(); it != tasks.end(); it++) {
         it->wait();
         ret.push_back(it->get());
@@ -483,10 +483,10 @@ double benchmark_loadwallet()
 {
     pre_wallet_load();
     struct timeval tv_start;
-    bool fFirstRunRet=true;
+    //bool fFirstRunRet=true;	// -Wunused-variable
     timer_start(tv_start);
     pwalletMain = new CWallet("wallet.dat");
-    DBErrors nLoadWalletRet = pwalletMain->LoadWallet(fFirstRunRet);
+    //DBErrors nLoadWalletRet = pwalletMain->LoadWallet(fFirstRunRet);	// -Wunused-variable
     auto res = timer_stop(tv_start);
     post_wallet_load();
     return res;
@@ -656,7 +656,7 @@ double benchmark_verify_sapling_output()
                 output.zkproof.begin()
             );
 
-    double t = timer_stop(tv_start);
+    //double t = timer_stop(tv_start);	// -Wunused-variable
     librustzcash_sapling_verification_ctx_free(ctx);
     if (!result) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "librustzcash_sapling_check_output() should return true");


### PR DESCRIPTION
This PR aims to greatly reduce CLang compile time warnings and slightly cleanup unused code segments.

It mostly addresses `-Wreorder-ctor`, `-Wunused-but-set-variable`, `-Wunused-variable` and `-Wunused-function`.